### PR TITLE
CI should run only once per commit

### DIFF
--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:

--- a/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
+++ b/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
@@ -3,7 +3,11 @@
 exports[`creates GitHub Actions setup migrates existing TravisCI configration supports scenario .travis-ci.yml.ember.3.8-npm 1`] = `
 "name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:
@@ -105,7 +109,11 @@ jobs:
 exports[`creates GitHub Actions setup migrates existing TravisCI configration supports scenario .travis-ci.yml.ember.3.12-npm 1`] = `
 "name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:
@@ -207,7 +215,11 @@ jobs:
 exports[`creates GitHub Actions setup migrates existing TravisCI configration supports scenario .travis-ci.yml.ember-3.4-npm 1`] = `
 "name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:
@@ -309,7 +321,11 @@ jobs:
 exports[`creates GitHub Actions setup migrates existing TravisCI configration supports scenario .travis-ci.yml.ember-3.16-npm 1`] = `
 "name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:
@@ -412,7 +428,11 @@ jobs:
 exports[`creates GitHub Actions setup migrates existing TravisCI configration supports scenario .travis-ci.yml.ember-3.20-npm 1`] = `
 "name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:
@@ -515,7 +535,11 @@ jobs:
 exports[`creates GitHub Actions setup migrates existing TravisCI configration supports scenario .travis-ci.yml.ember-3.20-yarn 1`] = `
 "name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:
@@ -619,7 +643,11 @@ jobs:
 exports[`creates GitHub Actions setup uses default values if no TravisCI configuration exists 1`] = `
 "name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
Before the CI was run twice if a pull request is created from a feature branch within the same repository (not a fork). The changes follow the recommendation given by @isaac in *When Should CI Run?* chapter of his blog post: [CI with GitHub Actions for Ember Apps](https://crunchingnumbers.live/2020/03/17/ci-with-github-actions-for-ember-apps/)

Closes #5 