### PR TITLE
simplify cache setup

### DIFF
--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -55,8 +55,7 @@ jobs:
           %>yarn install --frozen-lockfile<%
         } %>
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Lint
       run: <% if (packageManager === 'npm') { %>npm run-script<% } else { %>yarn<% } %> lint
@@ -114,8 +113,7 @@ jobs:
           %>yarn install --frozen-lockfile<%
         } %>
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: <% if (packageManager === 'npm') { %>npm run-script<% } else { %>yarn<% } %> test:ember --launch ${{ matrix.browser }}
@@ -173,8 +171,7 @@ jobs:
           %>yarn install --frozen-lockfile<%
         } %>
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: <% if (packageManager === 'npm') { %>npm run-script<% } else { %>yarn<% } %> test:ember --launch ${{ matrix.browser }}
@@ -241,8 +238,7 @@ jobs:
           %>yarn install --frozen-lockfile<%
         } %>
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       env:

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -31,43 +31,21 @@ jobs:
           %>yarn cache dir<%
         } %>)"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: ${{ steps.global-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-${{ matrix.node-version }}-<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>-${{ hashFiles('**/<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>') }}
+        key: ${{ runner.os }}-${{ matrix.node-version }}-${{
+          hashFiles('**/<%
+            if (packageManager === 'npm') {
+              %>package-lock.json<%
+            } else {
+              %>yarn.lock<%
+            } %>'
+          ) }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+          ${{ runner.os }}-${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: <%
@@ -112,43 +90,21 @@ jobs:
           %>yarn cache dir<%
         } %>)"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: ${{ steps.global-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-${{ matrix.node-version }}-<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>-${{ hashFiles('**/<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>') }}
+        key: ${{ runner.os }}-${{ matrix.node-version }}-${{
+          hashFiles('**/<%
+            if (packageManager === 'npm') {
+              %>package-lock.json<%
+            } else {
+              %>yarn.lock<%
+            } %>'
+          ) }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+          ${{ runner.os }}-${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: <%
@@ -193,43 +149,21 @@ jobs:
           %>yarn cache dir<%
         } %>)"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: ${{ steps.global-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-${{ matrix.node-version }}-<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>-${{ hashFiles('**/<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>') }}
+        key: ${{ runner.os }}-${{ matrix.node-version }}-${{
+          hashFiles('**/<%
+            if (packageManager === 'npm') {
+              %>package-lock.json<%
+            } else {
+              %>yarn.lock<%
+            } %>'
+          ) }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+          ${{ runner.os }}-${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: <%
@@ -283,43 +217,21 @@ jobs:
           %>yarn cache dir<%
         } %>)"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: ${{ steps.global-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-${{ matrix.node-version }}-<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>-${{ hashFiles('**/<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>') }}
+        key: ${{ runner.os }}-${{ matrix.node-version }}-${{
+          hashFiles('**/<%
+            if (packageManager === 'npm') {
+              %>package-lock.json<%
+            } else {
+              %>yarn.lock<%
+            } %>'
+          ) }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/<%
-          if (packageManager === 'npm') {
-            %>package-lock.json<%
-          } else {
-            %>yarn.lock<%
-          } %>') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
+          ${{ runner.os }}-${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: <%

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           ${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: ${{ runner.os }}-${{ matrix.node-version }}-${{
@@ -95,7 +95,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           ${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: ${{ runner.os }}-${{ matrix.node-version }}-${{
@@ -155,7 +155,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           ${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: ${{ runner.os }}-${{ matrix.node-version }}-${{
@@ -224,7 +224,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           ${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: ${{ runner.os }}-${{ matrix.node-version }}-${{

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: ${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          ${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: ${{ runner.os }}-${{ matrix.node-version }}-${{
           hashFiles('**/<%
             if (packageManager === 'npm') {
@@ -93,7 +95,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: ${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          ${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: ${{ runner.os }}-${{ matrix.node-version }}-${{
           hashFiles('**/<%
             if (packageManager === 'npm') {
@@ -151,7 +155,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: ${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          ${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: ${{ runner.os }}-${{ matrix.node-version }}-${{
           hashFiles('**/<%
             if (packageManager === 'npm') {
@@ -218,7 +224,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: ${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          ${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: ${{ runner.os }}-${{ matrix.node-version }}-${{
           hashFiles('**/<%
             if (packageManager === 'npm') {

--- a/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
+++ b/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
@@ -43,8 +43,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Lint
       run: npm run-script lint
@@ -87,8 +86,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -131,8 +129,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -186,8 +183,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       env:
@@ -239,8 +235,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Lint
       run: npm run-script lint
@@ -283,8 +278,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -327,8 +321,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -382,8 +375,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       env:
@@ -435,8 +427,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Lint
       run: npm run-script lint
@@ -479,8 +470,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -523,8 +513,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -578,8 +567,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       env:
@@ -631,8 +619,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Lint
       run: npm run-script lint
@@ -675,8 +662,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -719,8 +705,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -775,8 +760,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       env:
@@ -828,8 +812,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Lint
       run: npm run-script lint
@@ -872,8 +855,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -916,8 +898,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -972,8 +953,7 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       env:
@@ -1025,8 +1005,7 @@ jobs:
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Lint
       run: yarn lint
@@ -1069,8 +1048,7 @@ jobs:
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: yarn test:ember --launch \${{ matrix.browser }}
@@ -1113,8 +1091,7 @@ jobs:
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: yarn test:ember --launch \${{ matrix.browser }}
@@ -1170,8 +1147,7 @@ jobs:
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       env:
@@ -1223,8 +1199,7 @@ jobs:
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Lint
       run: yarn lint
@@ -1267,8 +1242,7 @@ jobs:
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: yarn test:ember --launch \${{ matrix.browser }}
@@ -1311,8 +1285,7 @@ jobs:
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: yarn test:ember --launch \${{ matrix.browser }}
@@ -1369,8 +1342,7 @@ jobs:
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
       if: |
-        steps.cache-global-package-manager-cache.outputs.cache-hit != 'true' ||
-        steps.cache-node-modules.outputs.cache-hit != 'true'
+        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       env:

--- a/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
+++ b/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
@@ -33,7 +33,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -76,7 +78,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -119,7 +123,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -173,7 +179,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -225,7 +233,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -268,7 +278,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -311,7 +323,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -365,7 +379,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -417,7 +433,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -460,7 +478,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -503,7 +523,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -557,7 +579,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -609,7 +633,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -652,7 +678,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -695,7 +723,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -750,7 +780,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -802,7 +834,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -845,7 +879,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -888,7 +924,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -943,7 +981,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/package-lock.json'
           ) }}
@@ -995,7 +1035,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/yarn.lock'
           ) }}
@@ -1038,7 +1080,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/yarn.lock'
           ) }}
@@ -1081,7 +1125,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/yarn.lock'
           ) }}
@@ -1137,7 +1183,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/yarn.lock'
           ) }}
@@ -1189,7 +1237,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/yarn.lock'
           ) }}
@@ -1232,7 +1282,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/yarn.lock'
           ) }}
@@ -1275,7 +1327,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/yarn.lock'
           ) }}
@@ -1332,7 +1386,9 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path: \${{ steps.global-cache-dir-path.outputs.dir }}
+        path:
+          \${{ steps.global-cache-dir-path.outputs.dir }}
+          node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
           hashFiles('**/yarn.lock'
           ) }}

--- a/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
+++ b/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
@@ -33,7 +33,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -78,7 +78,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -123,7 +123,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -179,7 +179,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -233,7 +233,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -278,7 +278,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -323,7 +323,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -379,7 +379,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -433,7 +433,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -478,7 +478,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -523,7 +523,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -579,7 +579,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -633,7 +633,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -678,7 +678,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -723,7 +723,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -780,7 +780,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -834,7 +834,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -879,7 +879,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -924,7 +924,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -981,7 +981,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -1035,7 +1035,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -1080,7 +1080,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -1125,7 +1125,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -1183,7 +1183,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -1237,7 +1237,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -1282,7 +1282,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -1327,7 +1327,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
@@ -1386,7 +1386,7 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v2
       with:
-        path:
+        path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{

--- a/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
+++ b/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
@@ -29,23 +29,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -80,23 +73,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -131,23 +117,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -193,23 +172,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -253,23 +225,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -304,23 +269,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -355,23 +313,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -417,23 +368,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -477,23 +421,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -528,23 +465,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -579,23 +509,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -641,23 +564,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -701,23 +617,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -752,23 +661,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -803,23 +705,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -866,23 +761,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -926,23 +814,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -977,23 +858,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -1028,23 +902,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -1091,23 +958,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(npm config get cache)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-\${{ hashFiles('**/package-lock.json') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/package-lock.json'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-package-lock.json-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm ci
@@ -1151,23 +1011,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(yarn cache dir)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-\${{ hashFiles('**/yarn.lock') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/yarn.lock'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
@@ -1202,23 +1055,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(yarn cache dir)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-\${{ hashFiles('**/yarn.lock') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/yarn.lock'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
@@ -1253,23 +1099,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(yarn cache dir)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-\${{ hashFiles('**/yarn.lock') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/yarn.lock'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
@@ -1317,23 +1156,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(yarn cache dir)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-\${{ hashFiles('**/yarn.lock') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/yarn.lock'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
@@ -1377,23 +1209,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(yarn cache dir)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-\${{ hashFiles('**/yarn.lock') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/yarn.lock'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
@@ -1428,23 +1253,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(yarn cache dir)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-\${{ hashFiles('**/yarn.lock') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/yarn.lock'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
@@ -1479,23 +1297,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(yarn cache dir)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-\${{ hashFiles('**/yarn.lock') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/yarn.lock'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
@@ -1544,23 +1355,16 @@ jobs:
       id: global-cache-dir-path
       run: echo \\"::set-output name=dir::$(yarn cache dir)\\"
 
-    - name: Cache package manager's global cache
-      id: cache-global-package-manager-cache
-      uses: actions/cache@v1
+    - name: Cache package manager's global cache and node_modules
+      id: cache-dependencies
+      uses: actions/cache@v2
       with:
         path: \${{ steps.global-cache-dir-path.outputs.dir }}
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-\${{ hashFiles('**/yarn.lock') }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
+          hashFiles('**/yarn.lock'
+          ) }}
         restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-yarn.lock-
-
-    - name: Cache node_modules
-      id: cache-node-modules
-      uses: actions/cache@v1
-      with:
-        path: node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-\${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          \${{ runner.os }}-\${{ matrix.node-version }}-nodemodules-
+          \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --frozen-lockfile


### PR DESCRIPTION
Simplifies the cache setup as proposed by @ijlee2 in https://github.com/jelhan/ember-style-modifier/pull/32#discussion_r532058330.

It does not address the question if both global package manager cache and `node_modules` or only one of them should be cached. As before both is cached.

Closes #13