### PR TITLE
Make configuration interface more flexible for upcoming use cases

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,14 @@ import parseTravisCiConfig from './parser/travis-ci';
 import path from 'path';
 import process from 'process';
 
+interface EmberTryScenario {
+  scenario: string;
+  allowedToFail: boolean;
+}
+
 interface ConfigurationInterface {
   browsers: string[];
-  emberTryScenarios: {
-    allowedToFail: string[];
-    required: string[];
-  };
+  emberTryScenarios: EmberTryScenario[];
   nodeVersion: string;
   packageManager: 'npm' | 'yarn';
 }
@@ -32,17 +34,40 @@ const templateFile = path.join(
 );
 const data: ConfigurationInterface = parseTravisCiConfig() ?? {
   browsers: ['chrome', 'firefox'],
-  emberTryScenarios: {
-    required: [
-      'ember-lts-3.16',
-      'ember-lts-3.20',
-      'ember-release',
-      'ember-beta',
-      'ember-default-with-jquery',
-      'ember-classic',
-    ],
-    allowedToFail: ['ember-canary', 'embroider-tests'],
-  },
+  emberTryScenarios: [
+    {
+      scenario: 'ember-lts-3.16',
+      allowedToFail: false,
+    },
+    {
+      scenario: 'ember-lts-3.20',
+      allowedToFail: false,
+    },
+    {
+      scenario: 'ember-release',
+      allowedToFail: false,
+    },
+    {
+      scenario: 'ember-beta',
+      allowedToFail: false,
+    },
+    {
+      scenario: 'ember-default-with-jquery',
+      allowedToFail: false,
+    },
+    {
+      scenario: 'ember-classic',
+      allowedToFail: false,
+    },
+    {
+      scenario: 'ember-canary',
+      allowedToFail: true,
+    },
+    {
+      scenario: 'embroider-tests',
+      allowedToFail: true,
+    },
+  ],
   nodeVersion: '10.x',
   packageManager: 'yarn',
 };
@@ -60,4 +85,4 @@ ejs.renderFile(templateFile, data, options, function (err, str) {
   fs.writeFileSync(gitHubActionsWorkflowFile, str);
 });
 
-export { ConfigurationInterface };
+export { ConfigurationInterface, EmberTryScenario };

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -193,12 +193,18 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario: [<%
-          emberTryScenarios.required.forEach(function(scenario, index){ %>
-          <%- scenario %><% if (index < emberTryScenarios.required.length - 1) { %>,<% }}); %>
+          emberTryScenarios
+            .filter(({ allowedToFail }) => !allowedToFail)
+            .forEach(function({ scenario }, index, requiredEmberTryScenarios) {
+              const isLastElement = requiredEmberTryScenarios.length - 1 === index; %>
+          <%- scenario %><% if (!isLastElement) { %>,<% }
+            }); %>
         ]
         allow-failure: [false]
         include:<%
-          emberTryScenarios.allowedToFail.forEach(function(scenario){ %>
+          emberTryScenarios
+            .filter(({ allowedToFail }) => allowedToFail)
+            .forEach(function({ scenario }) { %>
           - ember-try-scenario: <%- scenario %>
             allow-failure: true<% }); %>
 


### PR DESCRIPTION
This pull request changes the configuration interface used to be more flexible for upcoming use cases. One use case I had in mind is support for arbitrary environment variables (#12). Landing this change before introducing an update mechanism (#19) to reduce the likelihood of backward incompatible changes.