### PR TITLE
generated floating deps test must ignore lockfile

### DIFF
--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -189,9 +189,9 @@ jobs:
     - name: Install Dependencies
       run: <%
         if (packageManager === 'npm') {
-          %>npm ci<%
+          %>npm install --no-package-lock<%
         } else {
-          %>yarn install --frozen-lockfile<%
+          %>yarn install --no-lockfile --non-interactive<%
         } %>
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -175,14 +175,7 @@ jobs:
         path: |
           ${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: ${{ runner.os }}-${{ matrix.node-version }}-${{
-          hashFiles('**/<%
-            if (packageManager === 'npm') {
-              %>package-lock.json<%
-            } else {
-              %>yarn.lock<%
-            } %>'
-          ) }}
+        key: ${{ runner.os }}-${{ matrix.node-version }}-floating-deps
         restore-keys: |
           ${{ runner.os }}-${{ matrix.node-version }}-
 
@@ -193,8 +186,6 @@ jobs:
         } else {
           %>yarn install --no-lockfile --non-interactive<%
         } %>
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: <% if (packageManager === 'npm') { %>npm run-script<% } else { %>yarn<% } %> test:ember --launch ${{ matrix.browser }}

--- a/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
+++ b/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
@@ -159,16 +159,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/package-lock.json'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm install --no-package-lock
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -392,16 +388,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/package-lock.json'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm install --no-package-lock
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -625,16 +617,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/package-lock.json'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm install --no-package-lock
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -860,16 +848,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/package-lock.json'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm install --no-package-lock
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -1096,16 +1080,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/package-lock.json'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm install --no-package-lock
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -1334,16 +1314,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/yarn.lock'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --no-lockfile --non-interactive
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: yarn test:ember --launch \${{ matrix.browser }}
@@ -1569,16 +1545,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/package-lock.json'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm install --no-package-lock
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -1804,16 +1776,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/yarn.lock'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --no-lockfile --non-interactive
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: yarn test:ember --launch \${{ matrix.browser }}
@@ -2027,16 +1995,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/yarn.lock'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --no-lockfile --non-interactive
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: yarn test:ember --launch \${{ matrix.browser }}
@@ -2244,16 +2208,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/package-lock.json'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: npm install --no-package-lock
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: npm run-script test:ember --launch \${{ matrix.browser }}
@@ -2461,16 +2421,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/yarn.lock'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --no-lockfile --non-interactive
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: yarn test:ember --launch \${{ matrix.browser }}
@@ -2679,16 +2635,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/yarn.lock'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --no-lockfile --non-interactive
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: yarn test:ember --launch \${{ matrix.browser }}
@@ -2896,16 +2848,12 @@ jobs:
         path: |
           \${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: \${{ runner.os }}-\${{ matrix.node-version }}-\${{
-          hashFiles('**/yarn.lock'
-          ) }}
+        key: \${{ runner.os }}-\${{ matrix.node-version }}-floating-deps
         restore-keys: |
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --no-lockfile --non-interactive
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: yarn test:ember --launch \${{ matrix.browser }}

--- a/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
+++ b/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
@@ -166,7 +166,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: npm ci
+      run: npm install --no-package-lock
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
@@ -399,7 +399,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: npm ci
+      run: npm install --no-package-lock
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
@@ -632,7 +632,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: npm ci
+      run: npm install --no-package-lock
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
@@ -867,7 +867,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: npm ci
+      run: npm install --no-package-lock
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
@@ -1103,7 +1103,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: npm ci
+      run: npm install --no-package-lock
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
@@ -1341,7 +1341,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: yarn install --frozen-lockfile
+      run: yarn install --no-lockfile --non-interactive
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
@@ -1576,7 +1576,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: npm ci
+      run: npm install --no-package-lock
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
@@ -1811,7 +1811,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: yarn install --frozen-lockfile
+      run: yarn install --no-lockfile --non-interactive
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
@@ -2034,7 +2034,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: yarn install --frozen-lockfile
+      run: yarn install --no-lockfile --non-interactive
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
@@ -2251,7 +2251,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: npm ci
+      run: npm install --no-package-lock
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
@@ -2468,7 +2468,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: yarn install --frozen-lockfile
+      run: yarn install --no-lockfile --non-interactive
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
@@ -2686,7 +2686,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: yarn install --frozen-lockfile
+      run: yarn install --no-lockfile --non-interactive
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 
@@ -2903,7 +2903,7 @@ jobs:
           \${{ runner.os }}-\${{ matrix.node-version }}-
 
     - name: Install Dependencies
-      run: yarn install --frozen-lockfile
+      run: yarn install --no-lockfile --non-interactive
       if: |
         steps.cache-dependencies.outputs.cache-hit != 'true'
 


### PR DESCRIPTION
This bug was introduced in #11 and present since v0.2.0.