### PR TITLE
All Ember Try Scenarios should run if one fails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import yaml from 'js-yaml';
 
 interface EmberTryScenario {
   scenario: string;
-  allowedToFail: boolean;
 }
 
 interface ConfigurationInterface {

--- a/src/parser/defaults.ts
+++ b/src/parser/defaults.ts
@@ -102,7 +102,6 @@ async function determineEmberTryScenarios(): Promise<EmberTryScenario[]> {
       ({ name }: { name: string }): EmberTryScenario => {
         return {
           scenario: name,
-          allowedToFail: false,
         };
       }
     ) ?? []

--- a/src/parser/travis-ci.ts
+++ b/src/parser/travis-ci.ts
@@ -76,11 +76,6 @@ export default async function parseTravisCiConfig(): Promise<ConfigurationInterf
 
       return {
         scenario: value,
-        allowedToFail: config.jobs.allow_failures.some(
-          ({ env: envAllowedToFail }: { env: unknown }) => {
-            return envAllowedToFail === env;
-          }
-        ),
       };
     })
     .filter((_: string | null) => _ !== null);

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
   try-scenarios:
     name: Tests - ${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -202,19 +202,11 @@ jobs:
       matrix:
         ember-try-scenario: [<%
           emberTryScenarios
-            .filter(({ allowedToFail }) => !allowedToFail)
             .forEach(function({ scenario }, index, requiredEmberTryScenarios) {
               const isLastElement = requiredEmberTryScenarios.length - 1 === index; %>
           <%- scenario %><% if (!isLastElement) { %>,<% }
             }); %>
         ]
-        allow-failure: [false]
-        include:<%
-          emberTryScenarios
-            .filter(({ allowedToFail }) => allowedToFail)
-            .forEach(function({ scenario }) { %>
-          - ember-try-scenario: <%- scenario %>
-            allow-failure: true<% }); %>
 
     steps:
     - uses: actions/checkout@v2

--- a/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
+++ b/tests/acceptance/__snapshots__/creates-github-actions.test.ts.snap
@@ -19,17 +19,11 @@ exports[`creates GitHub Actions setup migrates existing TravisCI configration su
 #$   - chrome
 #$ emberTryScenarios:
 #$   - scenario: ember-lts-2.16
-#$     allowedToFail: false
 #$   - scenario: ember-lts-2.18
-#$     allowedToFail: false
 #$   - scenario: ember-release
-#$     allowedToFail: false
 #$   - scenario: ember-beta
-#$     allowedToFail: false
 #$   - scenario: ember-canary
-#$     allowedToFail: true
 #$   - scenario: ember-default-with-jquery
-#$     allowedToFail: false
 #$ nodeVersion: 6.x
 #$ packageManager: npm
 #
@@ -173,7 +167,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -184,12 +178,9 @@ jobs:
           ember-lts-2.18,
           ember-release,
           ember-beta,
+          ember-canary,
           ember-default-with-jquery
         ]
-        allow-failure: [false]
-        include:
-          - ember-try-scenario: ember-canary
-            allow-failure: true
 
     steps:
     - uses: actions/checkout@v2
@@ -248,17 +239,11 @@ exports[`creates GitHub Actions setup migrates existing TravisCI configration su
 #$   - chrome
 #$ emberTryScenarios:
 #$   - scenario: ember-lts-2.18
-#$     allowedToFail: false
 #$   - scenario: ember-lts-3.4
-#$     allowedToFail: false
 #$   - scenario: ember-release
-#$     allowedToFail: false
 #$   - scenario: ember-beta
-#$     allowedToFail: false
 #$   - scenario: ember-canary
-#$     allowedToFail: true
 #$   - scenario: ember-default-with-jquery
-#$     allowedToFail: false
 #$ nodeVersion: 6.x
 #$ packageManager: npm
 #
@@ -402,7 +387,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -413,12 +398,9 @@ jobs:
           ember-lts-3.4,
           ember-release,
           ember-beta,
+          ember-canary,
           ember-default-with-jquery
         ]
-        allow-failure: [false]
-        include:
-          - ember-try-scenario: ember-canary
-            allow-failure: true
 
     steps:
     - uses: actions/checkout@v2
@@ -477,17 +459,11 @@ exports[`creates GitHub Actions setup migrates existing TravisCI configration su
 #$   - chrome
 #$ emberTryScenarios:
 #$   - scenario: ember-lts-3.4
-#$     allowedToFail: false
 #$   - scenario: ember-lts-3.8
-#$     allowedToFail: false
 #$   - scenario: ember-release
-#$     allowedToFail: false
 #$   - scenario: ember-beta
-#$     allowedToFail: false
 #$   - scenario: ember-canary
-#$     allowedToFail: true
 #$   - scenario: ember-default-with-jquery
-#$     allowedToFail: false
 #$ nodeVersion: 8.x
 #$ packageManager: npm
 #
@@ -631,7 +607,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -642,12 +618,9 @@ jobs:
           ember-lts-3.8,
           ember-release,
           ember-beta,
+          ember-canary,
           ember-default-with-jquery
         ]
-        allow-failure: [false]
-        include:
-          - ember-try-scenario: ember-canary
-            allow-failure: true
 
     steps:
     - uses: actions/checkout@v2
@@ -706,19 +679,12 @@ exports[`creates GitHub Actions setup migrates existing TravisCI configration su
 #$   - chrome
 #$ emberTryScenarios:
 #$   - scenario: ember-lts-3.12
-#$     allowedToFail: false
 #$   - scenario: ember-lts-3.16
-#$     allowedToFail: false
 #$   - scenario: ember-release
-#$     allowedToFail: false
 #$   - scenario: ember-beta
-#$     allowedToFail: false
 #$   - scenario: ember-canary
-#$     allowedToFail: true
 #$   - scenario: ember-default-with-jquery
-#$     allowedToFail: false
 #$   - scenario: ember-classic
-#$     allowedToFail: false
 #$ nodeVersion: 10.x
 #$ packageManager: npm
 #
@@ -862,7 +828,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -873,13 +839,10 @@ jobs:
           ember-lts-3.16,
           ember-release,
           ember-beta,
+          ember-canary,
           ember-default-with-jquery,
           ember-classic
         ]
-        allow-failure: [false]
-        include:
-          - ember-try-scenario: ember-canary
-            allow-failure: true
 
     steps:
     - uses: actions/checkout@v2
@@ -938,19 +901,12 @@ exports[`creates GitHub Actions setup migrates existing TravisCI configration su
 #$   - chrome
 #$ emberTryScenarios:
 #$   - scenario: ember-lts-3.12
-#$     allowedToFail: false
 #$   - scenario: ember-lts-3.16
-#$     allowedToFail: false
 #$   - scenario: ember-release
-#$     allowedToFail: false
 #$   - scenario: ember-beta
-#$     allowedToFail: false
 #$   - scenario: ember-canary
-#$     allowedToFail: true
 #$   - scenario: ember-default-with-jquery
-#$     allowedToFail: false
 #$   - scenario: ember-classic
-#$     allowedToFail: false
 #$ nodeVersion: 10.x
 #$ packageManager: npm
 #
@@ -1094,7 +1050,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -1105,13 +1061,10 @@ jobs:
           ember-lts-3.16,
           ember-release,
           ember-beta,
+          ember-canary,
           ember-default-with-jquery,
           ember-classic
         ]
-        allow-failure: [false]
-        include:
-          - ember-try-scenario: ember-canary
-            allow-failure: true
 
     steps:
     - uses: actions/checkout@v2
@@ -1170,21 +1123,13 @@ exports[`creates GitHub Actions setup migrates existing TravisCI configration su
 #$   - chrome
 #$ emberTryScenarios:
 #$   - scenario: ember-lts-3.12
-#$     allowedToFail: false
 #$   - scenario: ember-lts-3.16
-#$     allowedToFail: false
 #$   - scenario: ember-lts-3.20
-#$     allowedToFail: false
 #$   - scenario: ember-release
-#$     allowedToFail: false
 #$   - scenario: ember-beta
-#$     allowedToFail: false
 #$   - scenario: ember-canary
-#$     allowedToFail: true
 #$   - scenario: ember-default-with-jquery
-#$     allowedToFail: false
 #$   - scenario: ember-classic
-#$     allowedToFail: false
 #$ nodeVersion: 10.x
 #$ packageManager: yarn
 #
@@ -1328,7 +1273,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -1340,13 +1285,10 @@ jobs:
           ember-lts-3.20,
           ember-release,
           ember-beta,
+          ember-canary,
           ember-default-with-jquery,
           ember-classic
         ]
-        allow-failure: [false]
-        include:
-          - ember-try-scenario: ember-canary
-            allow-failure: true
 
     steps:
     - uses: actions/checkout@v2
@@ -1559,7 +1501,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -1570,12 +1512,9 @@ jobs:
           ember-lts-2.18,
           ember-release,
           ember-beta,
+          ember-canary,
           ember-default-with-jquery
         ]
-        allow-failure: [false]
-        include:
-          - ember-try-scenario: ember-canary
-            allow-failure: true
 
     steps:
     - uses: actions/checkout@v2
@@ -1634,19 +1573,12 @@ exports[`creates GitHub Actions setup uses default values if no other parser mat
 #$   - Chrome
 #$ emberTryScenarios:
 #$   - scenario: ember-lts-3.16
-#$     allowedToFail: false
 #$   - scenario: ember-lts-3.20
-#$     allowedToFail: false
 #$   - scenario: ember-release
-#$     allowedToFail: false
 #$   - scenario: ember-beta
-#$     allowedToFail: false
 #$   - scenario: ember-canary
-#$     allowedToFail: false
 #$   - scenario: ember-default-with-jquery
-#$     allowedToFail: false
 #$   - scenario: ember-classic
-#$     allowedToFail: false
 #$ nodeVersion: '10'
 #$ packageManager: yarn
 #
@@ -1790,7 +1722,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -1805,8 +1737,6 @@ jobs:
           ember-default-with-jquery,
           ember-classic
         ]
-        allow-failure: [false]
-        include:
 
     steps:
     - uses: actions/checkout@v2
@@ -1865,7 +1795,6 @@ exports[`creates GitHub Actions setup uses default values if no other parser mat
 #$   - Chrome
 #$ emberTryScenarios:
 #$   - scenario: ember-lts-3.12
-#$     allowedToFail: false
 #$ nodeVersion: '6'
 #$ packageManager: yarn
 #
@@ -2009,7 +1938,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -2018,8 +1947,6 @@ jobs:
         ember-try-scenario: [
           ember-lts-3.12
         ]
-        allow-failure: [false]
-        include:
 
     steps:
     - uses: actions/checkout@v2
@@ -2078,7 +2005,6 @@ exports[`creates GitHub Actions setup uses default values if no other parser mat
 #$   - Chrome
 #$ emberTryScenarios:
 #$   - scenario: ember-lts-3.12
-#$     allowedToFail: false
 #$ nodeVersion: '10'
 #$ packageManager: npm
 #
@@ -2222,7 +2148,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -2231,8 +2157,6 @@ jobs:
         ember-try-scenario: [
           ember-lts-3.12
         ]
-        allow-failure: [false]
-        include:
 
     steps:
     - uses: actions/checkout@v2
@@ -2291,7 +2215,6 @@ exports[`creates GitHub Actions setup uses default values if no other parser mat
 #$   - Chrome
 #$ emberTryScenarios:
 #$   - scenario: ember-lts-3.12
-#$     allowedToFail: false
 #$ nodeVersion: '6'
 #$ packageManager: yarn
 #
@@ -2435,7 +2358,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -2444,8 +2367,6 @@ jobs:
         ember-try-scenario: [
           ember-lts-3.12
         ]
-        allow-failure: [false]
-        include:
 
     steps:
     - uses: actions/checkout@v2
@@ -2505,7 +2426,6 @@ exports[`creates GitHub Actions setup uses default values if no other parser mat
 #$   - Firefox
 #$ emberTryScenarios:
 #$   - scenario: ember-lts-3.12
-#$     allowedToFail: false
 #$ nodeVersion: '6'
 #$ packageManager: yarn
 #
@@ -2649,7 +2569,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -2658,8 +2578,6 @@ jobs:
         ember-try-scenario: [
           ember-lts-3.12
         ]
-        allow-failure: [false]
-        include:
 
     steps:
     - uses: actions/checkout@v2
@@ -2718,7 +2636,6 @@ exports[`creates GitHub Actions setup uses default values if no other parser mat
 #$   - Chrome
 #$ emberTryScenarios:
 #$   - scenario: ember-lts-3.12
-#$     allowedToFail: false
 #$ nodeVersion: '10'
 #$ packageManager: yarn
 #
@@ -2862,7 +2779,7 @@ jobs:
   try-scenarios:
     name: Tests - \${{ matrix.ember-try-scenario }}
     runs-on: ubuntu-latest
-    continue-on-error: \${{ matrix.allow-failure }}
+    continue-on-error: true
     needs: test
 
     strategy:
@@ -2871,8 +2788,6 @@ jobs:
         ember-try-scenario: [
           ember-lts-3.12
         ]
-        allow-failure: [false]
-        include:
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This pull requests enables [`continue-on-error`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) for all Ember Try Scenarios. So far it was only set to `true` for scenarios, which were allowed to fail in Travis CI configuration. 

Travis CI's `allow-failure` option and GitHub Action's `continue-on-error` option are not comparable:

- The `allow-failure` option of Travis CI affects the result of the CI pipeline. The CI pipeline is still considered as successful even if a job, which `allow-failure: true`, is failed.
- The `continue-on-error` option provided by GitHub Action does not affect the result of the CI pipeline. A pipeline is considered as failing if _any_ job fails. Regardless if `continue-on-error` is `true` or `false` for the job. Instead the option controls if subsequent jobs are executed or not.

The difference between both and the need for an option like Travis CI's `allow-failure` in GitHub Actions is discussed in this thread: https://github.com/actions/runner/issues/2347

It makes sense to run all Ember Try Scenarios always regardless if one fails:

- It will often be very helpful for debugging to know which Ember Try Scenarios pass and which are failing. Therefore it makes sense to run them all regardless if one already failed.
- Having `continue-on-error: true` reduces complexity and prevents certain edge cases by design (#43).
- The only downside, which I'm aware of, is more workload caused by CI. This may affect budget for private projects and may be bad from climate perspective.

Fixes actions/toolkit#43 